### PR TITLE
feat: 🎸 Configurable max pool size for JDBC data sources

### DIFF
--- a/perun-oidc-server-webapp/src/main/webapp/WEB-INF/data-context.xml
+++ b/perun-oidc-server-webapp/src/main/webapp/WEB-INF/data-context.xml
@@ -29,7 +29,7 @@
 		<property name="jdbcUrl" value="${jdbc.url}" />
 		<property name="username" value="${jdbc.user}" />
 		<property name="password" value="${jdbc.password}" />
-		<property name="maximumPoolSize" value="50" />
+		<property name="maximumPoolSize" value="${jdbc.max_pool_size}" />
 	</bean>
 
 	<bean id="mitreIdStats" class="com.zaxxer.hikari.HikariDataSource" destroy-method="close">
@@ -37,6 +37,7 @@
 		<property name="jdbcUrl" value="${stats.jdbc.url}" />
 		<property name="username" value="${stats.jdbc.user}" />
 		<property name="password" value="${stats.jdbc.password}" />
+		<property name="maximumPoolSize" value="${stats.jdbc.max_pool_size}"/>
 	</bean>
 
 	<bean id="jpaAdapter" class="org.springframework.orm.jpa.vendor.EclipseLinkJpaVendorAdapter">

--- a/perun-oidc-server-webapp/src/main/webapp/WEB-INF/user-context.xml
+++ b/perun-oidc-server-webapp/src/main/webapp/WEB-INF/user-context.xml
@@ -124,6 +124,7 @@
 				<prop key="jdbc.user">oidc</prop>
 				<prop key="jdbc.password">oidc</prop>
 				<prop key="jdbc.platform">org.eclipse.persistence.platform.database.MySQLPlatform</prop>
+				<prop key="jdbc.max_pool_size">50</prop>
 				<!-- SAML AUTH -->
 				<prop key="saml.entityID">https://login.cesnet.cz/oidc/</prop>
 				<prop key="saml.keystore.location">/etc/perun/perun-mitreid-saml-keystore.jks</prop>
@@ -143,6 +144,7 @@
 				<prop key="stats.jdbc.url">jdbc:mariadb://localhost:3306/STATS</prop>
 				<prop key="stats.jdbc.user">user</prop>
 				<prop key="stats.jdbc.password">password</prop>
+				<prop key="stats.jdbc.max_pool_size">10</prop>
 				<!-- WEB INTERFACE -->
 				<prop key="web.theme">default</prop>
 				<prop key="web.langs">EN</prop> <!-- EN,CS,SK -->


### PR DESCRIPTION
use `jdbc.max_pool_size` for MitreID db pool size limitation. Use
`stats.jdbc.max_pool_size` for limiting the pool size for statistics
data source