### PR TITLE
fix: 🐛 Fix missing sub in ClaimSourceProduceContext

### DIFF
--- a/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/ga4gh/Ga4ghPassportAndVisaClaimSource.java
+++ b/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/ga4gh/Ga4ghPassportAndVisaClaimSource.java
@@ -162,6 +162,7 @@ public abstract class Ga4ghPassportAndVisaClaimSource extends ClaimSource {
                                          ArrayNode passport,
                                          Set<String> linkedIdentities)
     {
+        log.debug("GA4GH: {}", uriVariables);
         JsonNode response = callHttpJsonAPI(repo, uriVariables);
         if (response != null) {
             JsonNode visas = response.path(GA4GH_CLAIM);


### PR DESCRIPTION
bug caused some claims to not generate correctly (i.e. GA4GH passports
could not call the remote APIs due to missing user identifier extracted
from "sub" claim)