### PR TITLE
fix: 🐛 Set email verified to true

### DIFF
--- a/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/userInfo/PerunUserInfoCacheLoader.java
+++ b/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/userInfo/PerunUserInfoCacheLoader.java
@@ -227,8 +227,9 @@ public class PerunUserInfoCacheLoader extends CacheLoader<UserInfoCacheKey, User
 
     private void processEmail(Map<String, PerunAttributeValue> userAttributeValues, PerunUserInfo ui) {
         ui.setEmail(extractStringValue(emailMappings.getEmail(), userAttributeValues));
-        ui.setEmailVerified(Boolean.parseBoolean(
-                extractStringValue(emailMappings.getEmailVerified(), userAttributeValues)));
+        //ui.setEmailVerified(Boolean.parseBoolean(extractStringValue(emailMappings.getEmailVerified(), userAttributeValues)));
+        //TODO: temporary solution - Perun requires email verification, so we can hardcode it to "TRUE"
+        ui.setEmailVerified(true);
     }
 
     private void processAddress(Map<String, PerunAttributeValue> userAttributeValues, PerunUserInfo ui) {


### PR DESCRIPTION
Perun requires e-mail verification, so we can hardcode the value of
email_verified to "true"