### PR TITLE
fix: show unapproved message

### DIFF
--- a/perun-oidc-server-webapp/src/main/webapp/WEB-INF/views/unapproved_spec.jsp
+++ b/perun-oidc-server-webapp/src/main/webapp/WEB-INF/views/unapproved_spec.jsp
@@ -21,7 +21,7 @@ pageContext.setAttribute("cssLinks", cssLinks);
 <div id="content">
     <div class="error_message" style="word-wrap: break-word;">
         <h1><spring:message code="${outHeader}"/></h1>
-        <p><sprign:message code="${outMessage}"/></p>
+        <p><spring:message code="${outMessage}"/></p>
         <p><spring:message code="contact_p"/>${" "}<a href="mailto:${contactMail}">${contactMail}</a></p>
     </div>
 </div>


### PR DESCRIPTION
it was not shown because of a typo in the template