### PR TITLE
fix: 🐛 Fix nullPointerexception in AuthProcFilterInit

### DIFF
--- a/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/filters/AuthProcFiltersContainer.java
+++ b/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/filters/AuthProcFiltersContainer.java
@@ -6,6 +6,7 @@ import static cz.muni.ics.oidc.server.filters.AuthProcFilterConstants.DEVICE_APP
 import cz.muni.ics.oauth2.model.ClientDetailsEntity;
 import cz.muni.ics.oauth2.service.ClientDetailsEntityService;
 import cz.muni.ics.oidc.BeanUtil;
+import cz.muni.ics.oidc.exceptions.ConfigurationException;
 import cz.muni.ics.oidc.models.Facility;
 import cz.muni.ics.oidc.models.PerunUser;
 import cz.muni.ics.oidc.saml.SamlProperties;
@@ -74,7 +75,7 @@ public class AuthProcFiltersContainer extends GenericFilterBean {
     }
 
     @PostConstruct
-    public void postConstruct() {
+    public void postConstruct() throws ConfigurationException {
         this.filters = AuthProcFiltersInitializer.initialize(properties, beanUtil);
     }
 

--- a/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/filters/AuthProcFiltersInitializer.java
+++ b/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/filters/AuthProcFiltersInitializer.java
@@ -1,6 +1,7 @@
 package cz.muni.ics.oidc.server.filters;
 
 import cz.muni.ics.oidc.BeanUtil;
+import cz.muni.ics.oidc.exceptions.ConfigurationException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.LinkedList;
@@ -22,7 +23,7 @@ public class AuthProcFiltersInitializer {
     private static final String FILTER_NAMES = "filter.names";
     private static final String FILTERS_PROP_BASE_PREFIX = "filter.";
 
-    public static List<AuthProcFilter> initialize(Properties coreProperties, BeanUtil beanUtil) {
+    public static List<AuthProcFilter> initialize(Properties coreProperties, BeanUtil beanUtil) throws ConfigurationException {
         List<AuthProcFilter> filters = new LinkedList<>();
 
         String filterNames = coreProperties.getProperty(FILTER_NAMES);
@@ -39,11 +40,11 @@ public class AuthProcFiltersInitializer {
         return filters;
     }
 
-    private static AuthProcFilter loadFilter(AuthProcFilterInitContext ctx) {
+    private static AuthProcFilter loadFilter(AuthProcFilterInitContext ctx) throws ConfigurationException {
         String filterClass = ctx.getFilterClass();
         if (!StringUtils.hasText(filterClass)) {
             log.warn("{} - failed to initialized filter: no class has ben configured", ctx.getFilterName());
-            return null;
+            throw new ConfigurationException("Failed to initialize filter '" + ctx.getFilterName() + "' ("  + filterClass + ")");
         }
         log.debug("{} - loading class '{}'", ctx.getFilterName(), filterClass);
 
@@ -52,25 +53,27 @@ public class AuthProcFiltersInitializer {
             if (!AuthProcFilter.class.isAssignableFrom(rawClazz)) {
                 log.warn("{} - failed to initialized filter: class '{}' does not extend AuthProcFilter",
                         ctx.getFilterName(), filterClass);
-                return null;
+                throw new ConfigurationException("Failed to initialize filter '" + ctx.getFilterName() + "' ("  + filterClass + ")");
             }
 
             @SuppressWarnings("unchecked") Class<AuthProcFilter> clazz = (Class<AuthProcFilter>) rawClazz;
             Constructor<AuthProcFilter> constructor = clazz.getConstructor(AuthProcFilterInitContext.class);
-            return constructor.newInstance(ctx);
+            AuthProcFilter filter = constructor.newInstance(ctx);
+            log.debug("Initialized AuthProcFilter - {}", filter);
+            return filter;
         } catch (ClassNotFoundException e) {
             log.warn("{} - failed to initialize filter: class '{}' was not found", ctx.getFilterName(), filterClass);
             log.debug("{} - details:", ctx.getFilterName(), e);
-            return null;
+            throw new ConfigurationException("Failed to initialize filter '" + ctx.getFilterName() + "' ("  + filterClass + ")");
         } catch (NoSuchMethodException e) {
             log.warn("{} - failed to initialize filter: class '{}' does not have proper constructor",
                     ctx.getFilterName(), filterClass);
             log.debug("{} - details:", ctx.getFilterName(), e);
-            return null;
+            throw new ConfigurationException("Failed to initialize filter '" + ctx.getFilterName() + "' ("  + filterClass + ")");
         } catch (IllegalAccessException | InvocationTargetException | InstantiationException e) {
             log.warn("{} - failed to initialize filter: class '{}' cannot be instantiated", ctx.getFilterName(), filterClass);
             log.debug("{} - details:", ctx.getFilterName(), e);
-            return null;
+            throw new ConfigurationException("Failed to initialize filter '" + ctx.getFilterName() + "' ("  + filterClass + ")");
         }
     }
 


### PR DESCRIPTION
when failed to initialize filter, we have returned null and this caused
NullPointerExceptions when running filters