### PR TITLE
feat: Integration with sentry

### DIFF
--- a/perun-oidc-server-webapp/src/main/resources/logback.xml
+++ b/perun-oidc-server-webapp/src/main/resources/logback.xml
@@ -16,6 +16,8 @@
 		</encoder>
 	</appender>
 
+	<appender name="SENTRY" class="io.sentry.logback.SentryAppender" />
+
 	<!-- FILE -->
 	<appender name="FILE" class="ch.qos.logback.core.FileAppender">
 		<file>${log.file}.${log.file-extension}</file>
@@ -34,6 +36,7 @@
 
 	<root level="${log.level}">
 		<appender-ref ref="${log.to}"/>
+		<appender-ref ref="SENTRY"/>
 	</root>
 
 	<!-- SPRING -->
@@ -51,6 +54,7 @@
 	<logger name="org.mariadb" level="warn"/>
 	<logger name="org.postgresql" level="warn"/>
 	<logger name="net.javacrumbs.shedlock" level="error"/>
+	<logger name="io.sentry" level="trace"/>
 
 	<!-- OUR LOGGERS -->
 	<!-- PASSED FROM POM.XML / MAVEN BUILD PROPS -->

--- a/perun-oidc-server-webapp/src/main/webapp/WEB-INF/user-context.xml
+++ b/perun-oidc-server-webapp/src/main/webapp/WEB-INF/user-context.xml
@@ -121,8 +121,13 @@
 				<prop key="filter.stats.serviceProvidersMapTableName">statistics_sp</prop>
 				<prop key="filter.stats.idpIdColumnName">idpId</prop>
 				<prop key="filter.stats.spIdColumnName">spId</prop>
+				<prop key="sentry.config.location"/>
 			</props>
 		</property>
+	</bean>
+
+	<bean id="sentryConfiguration" class="cz.muni.ics.oidc.SentryConfiguration">
+		<constructor-arg name="perunOidcConfig" ref="perunOidcConfig"/>
 	</bean>
 
 	<bean id="coreProperties" class="org.springframework.beans.factory.config.PropertiesFactoryBean">
@@ -463,6 +468,7 @@
 		<property name="webClassesFilePath" value="${web.classes.path}"/>
 		<property name="emailContact" value="${email.contact}"/>
 		<property name="addClientIdToAcrs" value="${proxy.add_client_id_to_acrs}"/>
+		<property name="sentryConfigFileLocation" value="${sentry.config.location}"/>
 	</bean>
 
 	<bean id="facilityAttrsConfig" class="cz.muni.ics.oidc.server.configurations.FacilityAttrsConfig">

--- a/perun-oidc-server/pom.xml
+++ b/perun-oidc-server/pom.xml
@@ -159,7 +159,16 @@
 			<groupId>javax.persistence</groupId>
 			<artifactId>javax.persistence-api</artifactId>
 		</dependency>
-	</dependencies>
+		<!-- SENTRY -->
+		<dependency>
+			<groupId>io.sentry</groupId>
+			<artifactId>sentry-spring</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.sentry</groupId>
+			<artifactId>sentry-logback</artifactId>
+		</dependency>
+    </dependencies>
 
 	<build>
 		<plugins>

--- a/perun-oidc-server/src/main/java/cz/muni/ics/oidc/SentryConfiguration.java
+++ b/perun-oidc-server/src/main/java/cz/muni/ics/oidc/SentryConfiguration.java
@@ -1,0 +1,57 @@
+package cz.muni.ics.oidc;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import cz.muni.ics.oidc.server.configurations.PerunOidcConfig;
+import io.sentry.Sentry;
+import java.io.File;
+import java.io.IOException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+public class SentryConfiguration implements InitializingBean {
+
+    private final String configFileLocation;
+    private final String appVersion;
+
+    public SentryConfiguration(PerunOidcConfig perunOidcConfig) {
+        this.configFileLocation = perunOidcConfig.getSentryConfigFileLocation();
+        this.appVersion = perunOidcConfig.getPerunOIDCVersion();
+    }
+
+    @Override
+    public void afterPropertiesSet() {
+        if (!StringUtils.hasText(configFileLocation)) {
+            log.debug("Sentry will not be configured, configuration file location not provided");
+            return;
+        }
+        JsonNode configFile = parseConfigFile(configFileLocation);
+        if (configFile == null || configFile.isNull()) {
+            log.debug("Sentry will not be configured, could not parse configuration file");
+            return;
+        }
+        final String dsn = configFile.path("dsn").asText();
+        log.debug("Initializing Sentry '{}'", dsn);
+
+        Sentry.init(options -> {
+            options.setDsn(dsn);
+            options.setDebug(true);
+            options.setRelease(appVersion);
+            options.setEnableUncaughtExceptionHandler(true);
+        });
+    }
+
+    private JsonNode parseConfigFile(String file)
+    {
+        YAMLMapper mapper = new YAMLMapper();
+        try {
+            return mapper.readValue(new File(file), JsonNode.class);
+        } catch (IOException ex) {
+            log.error("Cannot read Sentry config file", ex);
+        }
+        return JsonNodeFactory.instance.nullNode();
+    }
+}

--- a/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
+++ b/perun-oidc-server/src/main/java/cz/muni/ics/oidc/server/configurations/PerunOidcConfig.java
@@ -13,6 +13,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
+import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
 
 /**
@@ -53,6 +54,8 @@ public class PerunOidcConfig {
 	private String webClassesFilePath;
 	private String emailContact;
 	private String rpcEnabled;
+
+	private String sentryConfigFileLocation;
 
 	public void setRpcUrl(String rpcUrl) {
 		this.rpcUrl = rpcUrl;
@@ -239,6 +242,14 @@ public class PerunOidcConfig {
 		this.addClientIdToAcrs = addClientIdToAcrs;
 	}
 
+	public String getSentryConfigFileLocation() {
+		return sentryConfigFileLocation;
+	}
+
+	public void setSentryConfigFileLocation(String sentryConfigFileLocation) {
+		this.sentryConfigFileLocation = sentryConfigFileLocation;
+	}
+
 	@PostConstruct
 	public void postInit() {
 		//load URLs from properties if available or construct them from issuer URL
@@ -284,6 +295,7 @@ public class PerunOidcConfig {
 			log.info("Available languages: {}", languageMap.keySet());
 			log.info("Localization files path: {}", localizationFilesPath);
 			log.info("Email contact: {}", emailContact);
+			log.info("Sentry enabled: {}", StringUtils.hasText(sentryConfigFileLocation));
 			log.info("Perun OIDC version: {}", getPerunOIDCVersion());
 		}
 	}

--- a/perun-oidc-server/src/main/java/cz/muni/ics/openid/connect/view/HttpCodeView.java
+++ b/perun-oidc-server/src/main/java/cz/muni/ics/openid/connect/view/HttpCodeView.java
@@ -23,6 +23,7 @@ package cz.muni.ics.openid.connect.view;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.view.AbstractView;
@@ -33,6 +34,7 @@ import org.springframework.web.servlet.view.AbstractView;
  *
  */
 @Component(HttpCodeView.VIEWNAME)
+@Slf4j
 public class HttpCodeView extends AbstractView {
 
 	public static final String VIEWNAME = "httpCodeView";
@@ -41,6 +43,7 @@ public class HttpCodeView extends AbstractView {
 
 	@Override
 	protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) {
+		log.debug("Handling");
 		HttpStatus code = (HttpStatus) model.get(CODE);
 		if (code == null) {
 			code = HttpStatus.OK; // default to 200

--- a/perun-oidc-server/src/main/java/cz/muni/ics/openid/connect/view/JsonErrorView.java
+++ b/perun-oidc-server/src/main/java/cz/muni/ics/openid/connect/view/JsonErrorView.java
@@ -23,6 +23,7 @@ import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
+import io.sentry.Sentry;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.Map;
@@ -77,7 +78,6 @@ public class JsonErrorView extends AbstractView {
 
 	@Override
 	protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request, HttpServletResponse response) {
-
 		response.setContentType(MediaType.APPLICATION_JSON_VALUE);
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,7 @@
 		<xml-bind-api.version>2.3.3</xml-bind-api.version>
 		<jaxb-runtime.version>2.3.6</jaxb-runtime.version>
 		<aspectjweaver.version>1.9.9.1</aspectjweaver.version>
+		<sentry.version>6.3.1</sentry.version>
 
 		<!-- BUILD -->
 		<java.version>11</java.version>
@@ -327,6 +328,13 @@
 				<groupId>org.apache.directory.api</groupId>
 				<artifactId>api-all</artifactId>
 				<version>${apache-ldap-api-all.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.sentry</groupId>
+				<artifactId>sentry-bom</artifactId>
+				<version>${sentry.version}</version>
+				<type>pom</type>
+				<scope>import</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
provide option `sentry.config.location` to enable sentry and load its
configuration. At the moment, configuration is expected to be a YAML
file with just DSN (key `dsn`) specified in it. This will be extended in
the future